### PR TITLE
Naming Conventions Consistency Adjustment #44

### DIFF
--- a/src/GLImporter.java
+++ b/src/GLImporter.java
@@ -107,7 +107,7 @@ public class GLImporter {
                 // Normalize attributes before checking for popular app
                 attributes = Normalizer.normalize(attributes);
                 // Check if the game name is in the popular apps list; skip if it is
-                String gameName = attributes.get("game");
+                String gameName = attributes.get("title");
                 if (gameName != null && Arrays.asList(Normalizer.popularApps).contains(gameName)) {
                     continue; // Skip this entry if it matches a popular app
                 }
@@ -116,7 +116,7 @@ public class GLImporter {
                 if (gameName != null) {
                     if (!gameName.startsWith("\"") && !gameName.endsWith("\"")) {
                         gameName = "\"" + gameName + "\"";
-                        attributes.put("game", gameName); // Update the attributes map with the quoted value
+                        attributes.put("title", gameName); // Update the attributes map with the quoted value
                     }
                 }
 

--- a/src/GUIDriver.java
+++ b/src/GUIDriver.java
@@ -518,7 +518,7 @@ public class GUIDriver extends Application {
     private void populateGameList(List<Game> games) {
         // Add imported games to the VBox and library, avoiding duplicates
         for (Game game : games) {
-            String gameName = game.getAttribute("game"); // Retrieves game name
+            String gameName = game.getAttribute("title"); // Retrieves game name
             String description = game.toString(); // Retrieves game details
             if (!library.contains(game)) { // Avoid adding the same game twice
                 library.add(game); // Add game to the library
@@ -681,12 +681,12 @@ public class GUIDriver extends Application {
         // If searchText is empty, display all games when search is clicked
         if (searchText.isEmpty()) {
             for (Game game : library) {
-                gameList.getChildren().add(createGameItem(game.getAttribute("game"), game.toString()));
+                gameList.getChildren().add(createGameItem(game.getAttribute("title"), game.toString()));
             }
         } else {
             // Filter the games based on the search keyword (searching both game name and description)
             for (Game game : library) {
-                String gameName = game.getAttribute("game").toLowerCase(); // Normalize game name to lowercase
+                String gameName = game.getAttribute("title").toLowerCase(); // Normalize game name to lowercase
                 String description = game.toString().toLowerCase(); // Normalize game description to lowercase
                 boolean matchFound = true;// Initialize the match flag
 
@@ -700,7 +700,7 @@ public class GUIDriver extends Application {
 
                 // If all terms match, add the game to the displayed game list and the results
                 if (matchFound) {
-                    gameList.getChildren().add(createGameItem(game.getAttribute("game"), game.toString()));
+                    gameList.getChildren().add(createGameItem(game.getAttribute("title"), game.toString()));
                     gameSearchResults.add(game); 
                 }
             }
@@ -906,7 +906,7 @@ public class GUIDriver extends Application {
         resetButton.setOnAction(event -> {
             gameList.getChildren().clear(); // Clear the current game list in the UI    
             for (Game game : library) {
-                gameList.getChildren().add(createGameItem(game.getAttribute("game"), game.toString()));
+                gameList.getChildren().add(createGameItem(game.getAttribute("title"), game.toString()));
             }
             textField.clear();
             keywordTextField.clear();
@@ -1094,7 +1094,7 @@ public class GUIDriver extends Application {
                     gameList.getChildren().clear(); //clear game list
                     if(sortedLibrary != null) {
                         for(Game game : sortedLibrary) { //populate game list
-                            gameList.getChildren().add(createGameItem(game.getAttribute("game"), game.toString()));
+                            gameList.getChildren().add(createGameItem(game.getAttribute("title"), game.toString()));
                         }
                     }
                 }

--- a/src/Game.java
+++ b/src/Game.java
@@ -99,7 +99,7 @@ public class Game {
 
 
     /**
-     * Provides a string representation of the game, summarizing all attributes except for those marked "N/A" or with the key "game".
+     * Provides a string representation of the game, summarizing all attributes except for those marked "N/A" or with the key "title".
      * 
      * @return A formatted string summarizing the game's attributes.
      */
@@ -127,8 +127,8 @@ public class Game {
             String key = entry.getKey();
             String value = entry.getValue();
 
-            // Skip attributes with key "game", any "N/A" or empty values, or keys already processed
-            if (key.equalsIgnoreCase("game") || value.equals("N/A") || value.isEmpty() || containsKey(preferredKeys, key)) {
+            // Skip attributes with key "title", any "N/A" or empty values, or keys already processed
+            if (key.equalsIgnoreCase("title") || value.equals("N/A") || value.isEmpty() || containsKey(preferredKeys, key)) {
                 continue;
             }
 
@@ -151,11 +151,11 @@ public class Game {
      * @return A formatted string for displaying the game.
      */
     public String toDisplayString() {
-        String gameName = attributes.get("game");
+        String gameName = attributes.get("title");
         if (gameName == null || gameName.isEmpty()) {
             gameName = "Unknown Game";
         }
-        return "Game: "+ gameName + " | " + this.toString();
+        return "Title: "+ gameName + " | " + this.toString();
     }
 
     /**
@@ -226,7 +226,7 @@ public class Game {
      * @return String representing the title of the game
      */
     public String getTitle() {
-        return getAttribute("game");
+        return getAttribute("title");
     }
 
     /**

--- a/src/ManualEntryTab.java
+++ b/src/ManualEntryTab.java
@@ -137,7 +137,7 @@ public class ManualEntryTab {
         Map<String, String> attributes = gameEntry.collectData();
         Game game = new Game(attributes);
         library.add(game);
-        gameList.getChildren().add(GUIDriver.createGameItem(game.getAttribute("game"), game.toString()));
+        gameList.getChildren().add(GUIDriver.createGameItem(game.getAttribute("title"), game.toString()));
     }
 
     // Clear the entries after submission
@@ -197,10 +197,10 @@ public class ManualEntryTab {
             defaultFieldsGrid.setVgap(5); // Vertical gap between grid cells
 
             // Create labels and text fields for default fields
-            Label nameLabel = new Label("Game Name:");
+            Label nameLabel = new Label("Title:");
             TextField nameField = new TextField();
-            nameField.setPromptText("Game Name"); // Placeholder text for the name field
-            defaultFields.put("game", nameField); // Add the field to the defaultFields map
+            nameField.setPromptText("Example Title"); // Placeholder text for the name field
+            defaultFields.put("title", nameField); // Add the field to the defaultFields map
 
             // Create labels and text fields for platform field
             Label platformLabel = new Label("Platform:");
@@ -282,7 +282,7 @@ public class ManualEntryTab {
                 String key = entry.getKey();
                 String value = entry.getValue().getText().trim(); // Get and trim the text input
                 // Ensure the game name field is enclosed in quotes
-                if ("game".equalsIgnoreCase(key)) {
+                if ("title".equalsIgnoreCase(key)) {
                     if (!value.startsWith("\"") && !value.endsWith("\"")) {
                         value = "\"" + value + "\"";
                     }

--- a/src/Normalizer.java
+++ b/src/Normalizer.java
@@ -41,7 +41,7 @@ import java.util.*;
 public class Normalizer {
     /*Lists of all the different versions of a normalized attribute*/
     //Since these lists won't change once we make them I just made them all constant String arrays, feel free to change if there's a more efficient way
-    private static final String game[] = {"game", "name", "title"};
+    private static final String title[] = {"game", "name", "title"};
     private static final String hours_played[] = {"hours"};
     private static final String last_played[] = {"last played", "last-played", "last_played"};
     private static final String release_date[] = {"release"};
@@ -81,9 +81,9 @@ public class Normalizer {
             String value = attributes.get(key);
 
             //Normalizes attributes that are for the game's name. The condition for the attribute not containing id is to prevent the program from considering "game id"
-            //The last condition is to make sure that once we've found the game's title, no other attributes with the word "game" in it will be considered
-            if(contains(key, game) && !key.contains("id") && !normAttributes.containsKey("game")){ 
-                normAttributes = populateNorm(normAttributes, "game", key, value);
+            //The last condition is to make sure that once we've found the game's title, no other attributes with the word "title" in it will be considered
+            if(contains(key, title) && !key.contains("id") && !normAttributes.containsKey("title")){ 
+                normAttributes = populateNorm(normAttributes, "title", key, value);
             }
             else if(contains(key, hours_played)){
                 normAttributes = populateNorm(normAttributes, "hours_played", key, value);
@@ -126,7 +126,7 @@ public class Normalizer {
      * @return Whether or not the attribute contains one of the words in the given array
      */
     private static boolean contains(String attribute, String[] normalized){
-        //I chose to use contains for the attribute names because it prevents us from having to consider all the versions of "game", "game-name", "game name", "game_name", etc.
+        //I chose to use contains for the attribute names because it prevents us from having to consider all the versions of "title", "game-name", "game name", "game_name", etc.
         //Might cause its own problems though
         for(String word: normalized){
             if(attribute.contains(word)){


### PR DESCRIPTION
- Swapped out "game" key for "title" throughout the whole program for better clarity regarding UX and usability/learnability. -- Tested & Verified

- Created map in editTab.java for display values (hours_played, "Hours Played" , etc.) to be able to display properly capitalized with spaces field names in the dropdown on the edit tab. the dropdown  options map to the proper keys in the backend to grab the default display values from the keys displayed in the dropdown. -- Tested & Verified

- Additionally  in the edit tab I added "Platform" and "Console" to the dropdown and removed "Captions."

- Made edit tab value fields function independently of each other. Previously you couldn't just enter ONLY values in the custom boxes without having something populating the dropdown above. This is no longer a requirement -- Tested & Verified

- Swapped "Game Name" listing in Manual Entry Tab to "Title:" with the associated default text now set to "Example Title" -- Tested & Verified